### PR TITLE
Adding babel-runtime and transform plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,14 @@
 {
-  "presets": [ "es2015" ]
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["last 2 versions", "iOS >=10", "ie >= 10"]
+      }
+    }]
+  ],
+  "plugins": [
+    "array-includes",
+    "transform-object-assign",
+    "transform-runtime",
+  ]
 }

--- a/example/cross_origin_communication/3_a_index.html
+++ b/example/cross_origin_communication/3_a_index.html
@@ -81,7 +81,7 @@
       <button class="button" id="btn-unmount">unmount</button>
     </p>
     <script>
-      XFC.Consumer.init()
+      XFC.Consumer.init();
       var frame = XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/cross_origin_communication/3_a_provider.html');
       var btn = document.getElementById('btn-unmount');
       btn.addEventListener('click', function() {

--- a/example/embedded_app_lifecycle/2_c_provider_consumer_app.html
+++ b/example/embedded_app_lifecycle/2_c_provider_consumer_app.html
@@ -13,6 +13,7 @@
       }
       html[hidden] { display: none; }
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js"></script>
   </head>
   <body>
     <div>

--- a/example/initialization/1_b_secret_function.html
+++ b/example/initialization/1_b_secret_function.html
@@ -10,6 +10,7 @@
       html[hidden] { display: none; }
     </style>
     <script src="http://localhost:8080/xfc.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js"></script>
   </head>
   <body>
     <div>

--- a/package.json
+++ b/package.json
@@ -20,15 +20,18 @@
     "test": "mocha --compilers js:babel-core/register --recursive"
   },
   "dependencies": {
-    "jsonrpc-dispatch": "^2.0.0",
+    "babel-runtime": "^6.26.0",
+    "jsonrpc-dispatch": "^2.3.0",
     "mutation-observer": "^1.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.7.5",
     "babel-core": "^6.7.7",
     "babel-loader": "^6.2.4",
-    "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.6.0",
+    "babel-plugin-array-includes": "^2.0.3",
+    "babel-plugin-transform-object-assign": "^6.22.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.0",
     "chai": "^3.5.0",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.1",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,7 +4,7 @@ const pkg = require('./package.json');
 
 module.exports = {
   entry: {
-    xfc: ['babel-polyfill', './src'],
+    xfc: ['./src'],
   },
   output: {
     filename: 'xfc.js',
@@ -28,5 +28,5 @@ module.exports = {
     host: '0.0.0.0',
     disableHostCheck: true,
   },
-  devtool: 'cheap-eval-source-map',
+  devtool: 'source-map',
 };


### PR DESCRIPTION

### Summary
Added babel-runtime and a couple transform plugins that remove the need of extra global polyfills.

### Additional Details
This won't pollute global so the consumer of xfc can still choose to include a global polyfill if they want. However, extra polyfills are not needed to consume this library.

Thanks for contributing to xfc.

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
