### PR TITLE
Reuse iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,18 @@ If the embedded app does not know which domain to trust, it may require secret a
 var frame = XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/provider_b.html', {secret: 'abc123'})
 ```
 
-To remove and clean up a mounted app, simple call `unmount` method.
+To remove and clean up a mounted app, simply call `unmount` method.
 
 ```js
 frame.unmount()
 ```
+
+To load a new page within the existing frame, simply call `load` method with the new URL.
+
+```js
+frame.load(newURL)
+```
+
 
 #### Iframe Resizing Config
 By default, the height of iframe will automatically resize based on the height of the embedded content. This behavior can be changed by passing an extra option (`resizeConfig`) into `mount` method.

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -141,6 +141,9 @@ class Frame extends EventEmitter {
     if (this.wrapper.parentNode === this.container) {
       this.container.removeChild(this.wrapper);
       this.emit('xfc.unmounted');
+      // Sets references of detached nodes to null to avoid memory leak
+      this.iframe = null;
+      this.wrapper = null;
     }
   }
 

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -18,6 +18,7 @@ class Frame extends EventEmitter {
     this.initIframeResizer = this.initIframeResizer.bind(this);
     this.send = this.send.bind(this);
     this.cleanup = this.cleanup.bind(this);
+    this.load = this.load.bind(this);
   }
 
   /**
@@ -81,10 +82,7 @@ class Frame extends EventEmitter {
         },
 
         loadPage(url) {
-          self.origin = new URI(url).origin;
-          self.source = url;
-          self.wrapper.setAttribute('data-status', 'mounted');
-          self.iframe.src = url; // Triggers the loading of new page
+          self.load(url);
           return Promise.resolve();
         },
       }
@@ -167,9 +165,10 @@ class Frame extends EventEmitter {
    * @param  {string} url - the URL of new page to load.
    */
   load(url) {
-    if (url) {
-      this.iframe.src = url;
-    }
+    this.origin = new URI(url).origin;
+    this.source = url;
+    this.wrapper.setAttribute('data-status', 'mounted');
+    this.iframe.src = url; // Triggers the loading of new page
   }
 
   /**

--- a/test/frame.js
+++ b/test/frame.js
@@ -66,7 +66,14 @@ describe('Frame', () => {
       it("emits 'xfc.unmounted' event", () => {
         sinon.assert.called(emit);
       });
+    });
 
+    describe('#load()', () => {
+      it("sets the iframe's src to newURL", () => {
+        const newURL = 'http://localhost:8080/test';
+        frame.load(newURL);
+        expect(frame.iframe.src).to.equal(newURL);
+      });
     });
 
     describe('#send(message)', () => {

--- a/test/frame.js
+++ b/test/frame.js
@@ -4,6 +4,7 @@ import JSONRPC from 'jsonrpc-dispatch';
 import sinon from 'sinon';
 
 import Frame from '../src/consumer/frame';
+import URI from '../src/lib/uri';
 
 
 describe('Frame', () => {
@@ -69,8 +70,17 @@ describe('Frame', () => {
     });
 
     describe('#load()', () => {
+      const newURL = 'http://localhost:8080/test';
+
+      it("sets the frame's origin to the origin of newURL", () => {
+        frame.load(newURL);
+        expect(frame.origin).to.equal(new URI(newURL).origin);
+      });
+      it("sets the frame's source to newURL", () => {
+        frame.load(newURL);
+        expect(frame.source).to.equal(newURL);
+      });
       it("sets the iframe's src to newURL", () => {
-        const newURL = 'http://localhost:8080/test';
         frame.load(newURL);
         expect(frame.iframe.src).to.equal(newURL);
       });

--- a/test/frame.js
+++ b/test/frame.js
@@ -53,15 +53,20 @@ describe('Frame', () => {
 
     describe('#unmount()', () => {
       const emit = sinon.stub();
+      frame.cleanup = sinon.stub();
       frame.on('xfc.unmounted', () => emit());
       frame.unmount();
 
       it("removes the wrapper from container's child nodes", () => {
         expect(frame.wrapper.parentNode).to.not.equal(frame.container);
       });
+      it("calls method 'cleanup'", () => {
+        sinon.assert.called(frame.cleanup);
+      });
       it("emits 'xfc.unmounted' event", () => {
         sinon.assert.called(emit);
       });
+
     });
 
     describe('#send(message)', () => {


### PR DESCRIPTION
### Summary
This PR adds a new method called `load` to frame so that user can use existing iframe to load a new page and skip the mounting step.
There's also a small improvement made in this PR to avoid potential memory leak.



[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
