### PR TITLE
Adding iframe check in handleProviderMessage for unmounted frames

### DIFF
--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -176,8 +176,8 @@ class Frame extends EventEmitter {
   * @param {object} event - The emitted message event.
   */
   handleProviderMessage(event) {
-    // 1. This isn't a JSONRPC message, exit.
-    if (!event.data.jsonrpc) return;
+    // 1. This isn't a JSONRPC message or iframe is null, exit.
+    if (!event.data.jsonrpc || !this.iframe) return;
 
     // 2. Identify the app the message came from.
     if (this.iframe.contentWindow !== event.source) return;

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -152,10 +152,13 @@ class Frame extends EventEmitter {
   }
 
   /**
-   * Cleans up references of detached nodes by setting them to null
-   * to avoid potential memory leak
+   * Cleans up unused message listeners and references of detached nodes
    */
   cleanup() {
+    // Remove listener for all incoming communication
+    window.removeEventListener('message', this.handleProviderMessage);
+
+    // Sets references of detached nodes to null to avoid potential memory leak
     this.iframe = null;
     this.wrapper = null;
   }


### PR DESCRIPTION
### Summary
This PR adds logic of iframe checking in handleProviderMessage so that it won't handle incoming messages for unmounted/cleaned frames.

### Additional Details
Without this PR, you might experience console errors like `calling "contentWindow" on null` (because `this.iframe` is null for unmounted frames) when you have multiple frames on the same page and some of them are unmounted.

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
