### PR TITLE
Adding the feature to pass in custom attributes for mounted iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/provide
 | customCalculationMethod | function | null           | When specified, XFC will use the given method to update iframe's size when necessary (e.g. dom changes, window resized, etc.)<br><br> NOTE: context `this` is provided as iframe to this method, so in the method you can access the iframe by accessing `this` |
 
 
+### Setting Custom Attributes on Iframe
+Sometimes, it's useful for developers to add more attributes onto mounted iframes. A common use case, for instance, is adding `allow` attribute to `<iframe>` tag for cross-origin iframes in Chrome 64+ (See reference [here][3]). In those cases, we can pass an extra option called `iframeAttrs` into `mount` method as follows.
+
+```js
+XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/provider.html', { iframeAttrs: { allow: 'geolocation; camera' }});
+```
+
+Here `iframeAttrs` is an object that contains entries, each of them being an entry of attribute's name and value.
+
+
 ### Monitoring Embedded App Lifecycles
 
 Application lifecycles go through 3 stages as they load:
@@ -227,3 +237,4 @@ Navigate to http://localconsumer.com:8080/example
 
 [1]: ./.babelrc#L5
 [2]: https://github.com/ai/browserslist#queries
+[3]: https://dev.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes

--- a/example/cross_origin_communication/3_a_index.html
+++ b/example/cross_origin_communication/3_a_index.html
@@ -82,7 +82,7 @@
     </p>
     <script>
       XFC.Consumer.init();
-      var frame = XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/cross_origin_communication/3_a_provider.html');
+      var frame = XFC.Consumer.mount(document.body, 'http://localprovider.com:8080/example/cross_origin_communication/3_a_provider.html', { 'iframeAttrs': {'allow': 'camera'}});
       var btn = document.getElementById('btn-unmount');
       btn.addEventListener('click', function() {
         frame.unmount();

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -26,10 +26,11 @@ class Frame extends EventEmitter {
   * @param {string} source - The url source of the application
   * @param {object} options - An optional parameter that contains a set of optional configs
   */
-  init(container, source, { secret = null, resizeConfig = {} } = {}) {
+  init(container, source, { secret = null, resizeConfig = {}, iframeAttrs = {} } = {}) {
     this.source = source;
     this.container = container;
     this.iframe = null;
+    this.iframeAttrs = iframeAttrs;
     this.wrapper = null;
     this.origin = new URI(this.source).origin;
     this.secret = secret;
@@ -134,6 +135,15 @@ class Frame extends EventEmitter {
       iframe.style.overflow = 'hidden';
       iframe.scrolling = 'no';
     }
+
+    // Put custom attributes on iframe if specified
+    Object.entries(this.iframeAttrs).forEach(([key, value]) => {
+      iframe[key] = value;
+    });
+    // Object.keys(this.iframeAttrs).forEach(
+    //   attr => { iframe[attr] = this.iframeAttrs[attr]; }
+    // );
+
     this.iframe = iframe;
     this.wrapper.appendChild(iframe);
 

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -138,7 +138,7 @@ class Frame extends EventEmitter {
 
     // Put custom attributes on iframe if specified
     Object.entries(this.iframeAttrs).forEach(([key, value]) => {
-      iframe[key] = value;
+      iframe.setAttribute(key, value);
     });
 
     this.iframe = iframe;

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -140,9 +140,6 @@ class Frame extends EventEmitter {
     Object.entries(this.iframeAttrs).forEach(([key, value]) => {
       iframe[key] = value;
     });
-    // Object.keys(this.iframeAttrs).forEach(
-    //   attr => { iframe[attr] = this.iframeAttrs[attr]; }
-    // );
 
     this.iframe = iframe;
     this.wrapper.appendChild(iframe);

--- a/test/consumer.js
+++ b/test/consumer.js
@@ -23,8 +23,9 @@ describe('Consumer', () => {
 
   describe('#mount(container, source, options)', () => {
     const container = document.body;
+    const iframeAttrs = { allow: 'camera; geolocation' };
     const source = 'http://test.com:8080/test';
-    const options = { secret: 123 };
+    const options = { secret: 123, iframeAttrs };
 
     it('returns a mounted frame with given container and source', () => {
       const frame = Consumer.mount(container, source);
@@ -39,6 +40,14 @@ describe('Consumer', () => {
       const frame = Consumer.mount(container, '*', options);
 
       expect(frame.secret).to.equal(options.secret);
+    });
+
+    it('returns a frame whose iframe has given custom attributes if provided', () => {
+      const frame = Consumer.mount(container, '*', options);
+
+      Object.entries(iframeAttrs).forEach(([key, value]) => {
+        expect(frame.iframe.getAttribute(key)).to.equal(value);
+      });
     });
   });
 

--- a/test/frame.js
+++ b/test/frame.js
@@ -15,25 +15,29 @@ describe('Frame', () => {
   describe('#init() with secret', () => {
     const container = document.body;
     const source = "*";
-    const options = { secret: 123 };
+    const iframeAttrs = { allow: 'camera' };
+    const options = { secret: 123, iframeAttrs };
     const frame = new Frame();
     frame.init(container, source, options);
 
     it('sets the container', () => expect(frame.container).to.equal(container));
     it('sets the source', () => expect(frame.source).to.equal(source));
     it('sets the secret', () => expect(frame.secret).to.equal(options.secret));
+    it('sets the iframeAttrs', () => expect(frame.iframeAttrs).to.equal(iframeAttrs));
     it('sets the JSONRPC', () => expect(frame.JSONRPC).to.be.an.instanceof(JSONRPC));
   });
 
   describe('#init() without secret', () => {
     const container = document.body;
     const source = 'http://test.com:8080/test';
+    const iframeAttrs = { allow: 'camera; geolocation' };
     const frame = new Frame();
-    frame.init(container, source);
+    frame.init(container, source, { iframeAttrs });
 
     it('sets the container', () => expect(frame.container).to.equal(container));
     it('sets the source', () => expect(frame.source).to.equal(source));
     it('sets the secret to null', () => expect(frame.secret).to.be.null);
+    it('sets the iframeAttrs', () => expect(frame.iframeAttrs).to.equal(iframeAttrs));
     it('sets the JSONRPC', () => expect(frame.JSONRPC).to.be.an.instanceof(JSONRPC));
 
     describe('#mount()', () => {
@@ -46,6 +50,11 @@ describe('Frame', () => {
       });
       it("sets the iframe's src to source", () => {
         expect(frame.iframe.src).to.equal(source);
+      });
+      it("sets the iframe's custom attributes", () => {
+        Object.entries(iframeAttrs).forEach(([key, value]) => {
+          expect(frame.iframe[key]).to.equal(value);
+        });
       });
       it("emits 'xfc.mounted' event", () => {
         sinon.assert.called(emit);

--- a/test/frame.js
+++ b/test/frame.js
@@ -53,7 +53,7 @@ describe('Frame', () => {
       });
       it("sets the iframe's custom attributes", () => {
         Object.entries(iframeAttrs).forEach(([key, value]) => {
-          expect(frame.iframe[key]).to.equal(value);
+          expect(frame.iframe.getAttribute(key)).to.equal(value);
         });
       });
       it("emits 'xfc.mounted' event", () => {


### PR DESCRIPTION
### Summary
The PR adds the feature of setting custom attributes on mounted iframe when calling `mount` method.

### Additional Details
It also resolves this issue #10 
