### PR TITLE
Added unload listener and trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Next Release
 -------------
-1.4.0
-------
-* Added trigger for frame unloading.
+* Added trigger for frame unloading. #18
 
 1.3.2
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Next Release
 -------------
-1.3.3
+1.4.0
 ------
 * Added trigger for frame unloading.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Next Release
 -------------
+1.3.3
+------
+* Added trigger for frame unloading.
+
 1.3.2
 ------
 * Updated default height calculation to max to account for dropdowns.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@ Cerner Corporation
 - Elliott Hoffman [@slor]
 - Greg Howdeshell [@poloka]
 - Matt Schile [@mschile]
+- Sam Milligan [@grneggandsam]
 
 [@mhemesath]: https://github.com/mhemesath
 [@kafkahw]: https://github.com/kafkahw
@@ -13,3 +14,4 @@ Cerner Corporation
 [@slor]: https://github.com/slor
 [@poloka]: https://github.com/poloka
 [@mschile]: https://github.com/mschile
+[@grneggandsam]: https://github.com/grneggandsam

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Application lifecycles go through 3 stages as they load:
 1. ```mounted``` The application frame has been appended to the DOM and is loading the remote application site.
 2. ```launched``` The application frame has loaded and the embedded application has begun authorization sequence. At this time the app is loaded, but is hidden to prevent clickjacking.
 3. ```authorized``` The application has approved authorization and is now visible.
+4. ```unload``` The application frame is about to unload due to redirect or other causes.
 
 These statuses are communicated to the consumer application environment in 2 ways.
 
@@ -136,6 +137,11 @@ frame.on('xfc.launched', function() {
 // Listen for a container to trigger an authorized event
 frame.on('xfc.authorized', function(detail) {
   console.log('authorized', detail);
+})
+
+// Listen for a container to trigger an unload event
+frame.on('xfc.unload', function(detail) {
+  console.log('unloading', detail);
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xfc",
-  "version": "1.4.0",
+  "version": "1.3.2",
   "description": "A Cross Frame Container that handles securely embedding web content into a 3rd party domain",
   "author": "Cerner Corporation",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xfc",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "A Cross Frame Container that handles securely embedding web content into a 3rd party domain",
   "author": "Cerner Corporation",
   "license": "Apache-2.0",

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -53,6 +53,13 @@ class Frame extends EventEmitter {
           return Promise.resolve();
         },
 
+        unload(detail = {}) {
+          debugger;
+          self.wrapper.setAttribute('data-status', 'unloading');
+          self.emit('xfc.unload', detail);
+          return Promise.resolve();
+        },
+
         resize(height = null, width = null) {
           if (typeof resizeConfig.customCalculationMethod === 'function') {
             resizeConfig.customCalculationMethod.call(self.iframe);

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -54,7 +54,6 @@ class Frame extends EventEmitter {
         },
 
         unload(detail = {}) {
-          debugger;
           self.wrapper.setAttribute('data-status', 'unloading');
           self.emit('xfc.unload', detail);
           return Promise.resolve();

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -54,7 +54,7 @@ class Frame extends EventEmitter {
         },
 
         unload(detail = {}) {
-          self.wrapper.setAttribute('data-status', 'unloading');
+          self.wrapper.setAttribute('data-status', 'unloaded');
           self.emit('xfc.unload', detail);
           return Promise.resolve();
         },

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -19,6 +19,7 @@ class Application extends EventEmitter {
     this.authorizeConsumer = this.authorizeConsumer.bind(this);
     this.verifyChallenge = this.verifyChallenge.bind(this);
     this.emitError = this.emitError.bind(this);
+    this.unload = this.unload.bind(this);
 
     // If the document referer (parent frame) origin is trusted, default that
     // to the active ACL;
@@ -115,8 +116,9 @@ class Application extends EventEmitter {
   */
   launch() {
     if (window.self !== window.top) {
-      // 1: Setup listeners for all incoming communication
+      // 1: Setup listeners for all incoming communication and beforeunload
       window.addEventListener('message', this.handleConsumerMessage);
+      window.addEventListener('beforeunload', this.unload);
 
       // 2: Begin launch and authorization sequence
       this.JSONRPC.notification('launch');
@@ -230,6 +232,13 @@ class Application extends EventEmitter {
    */
   emitError(error) {
     this.emit('xfc.error', error);
+  }
+
+  unload() {
+    const nextURL = document.activeElement.href;
+    const target = document.activeElement.target;
+
+    this.trigger('xfc.unload', { url: nextURL, target });
   }
 }
 

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -236,9 +236,8 @@ class Application extends EventEmitter {
 
   unload() {
     const nextURL = document.activeElement.href;
-    const target = document.activeElement.target;
 
-    this.trigger('xfc.unload', { url: nextURL, target });
+    this.trigger('xfc.unload', { url: nextURL });
   }
 }
 

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -236,7 +236,7 @@ class Application extends EventEmitter {
 
   unload() {
     this.JSONRPC.notification('unload');
-    this.trigger('xfc.unload', { url: document.activeElement.href });
+    this.trigger('xfc.unload');
   }
 }
 

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -235,9 +235,8 @@ class Application extends EventEmitter {
   }
 
   unload() {
-    const nextURL = document.activeElement.href;
-
-    this.trigger('xfc.unload', { url: nextURL });
+    this.JSONRPC.notification('unload');
+    this.trigger('xfc.unload', { url: document.activeElement.href });
   }
 }
 

--- a/test/application.js
+++ b/test/application.js
@@ -229,12 +229,11 @@ describe('Application', () => {
     });
 
     describe("#unload()", () => {
-      it("calls this.trigger with event 'xfc.unload' and last clicked item/href", sinon.test(function() {
+      it("calls this.trigger with event 'xfc.unload'", sinon.test(function() {
         const trigger = this.stub(application, 'trigger');
-        document.activeElement.href = 'alink.com';
         application.unload();
 
-        sinon.assert.calledWith(trigger, 'xfc.unload', { url: 'alink.com' });
+        sinon.assert.calledWith(trigger, 'xfc.unload');
       }));
     });
   });

--- a/test/application.js
+++ b/test/application.js
@@ -227,6 +227,17 @@ describe('Application', () => {
         expect(emittedError).to.equal(testErr);
       });
     });
+
+    describe("#unload()", () => {
+      it("calls this.trigger with event 'xfc.unload' and last clicked item/href", sinon.test(function() {
+        const trigger = this.stub(application, 'trigger');
+        document.activeElement.href = 'alink.com';
+        document.activeElement.target = '_self';
+        application.unload();
+
+        sinon.assert.calledWith(trigger, 'xfc.unload', { target: '_self', url: 'alink.com' });
+      }));
+    });
   });
 
   describe('#launch()', () => {

--- a/test/application.js
+++ b/test/application.js
@@ -232,10 +232,9 @@ describe('Application', () => {
       it("calls this.trigger with event 'xfc.unload' and last clicked item/href", sinon.test(function() {
         const trigger = this.stub(application, 'trigger');
         document.activeElement.href = 'alink.com';
-        document.activeElement.target = '_self';
         application.unload();
 
-        sinon.assert.calledWith(trigger, 'xfc.unload', { target: '_self', url: 'alink.com' });
+        sinon.assert.calledWith(trigger, 'xfc.unload', { url: 'alink.com' });
       }));
     });
   });


### PR DESCRIPTION
This is related to the issue here: https://github.com/cerner/xfc/issues/17

### Summary
This change gives consumers the ability to use callback functions triggered by 'beforeunload' events within the frame. This is useful to allow consumers to detect when content within the frame is about to be redirected and perform actions based on the event. This change also allows consumers to extract the url of a link click in the event a link caused the redirect.

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
