### PR TITLE
Added download attribute check for IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Next Release
 -------------
+* Added download attribute check for IE11 in unload trigger.
+
 1.5.0
 ------
 * Added support for calculating height of body containing absolute positioned elements.

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -260,6 +260,7 @@ class Application extends EventEmitter {
   }
 
   unload() {
+    // Need this line because IE11 & some safari trigger onbeforeunload despite presence of download attribute
     if (document.activeElement && document.activeElement.hasAttribute('download')) {
       return;
     }

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -260,6 +260,9 @@ class Application extends EventEmitter {
   }
 
   unload() {
+    if (document.activeElement && document.activeElement.hasAttribute('download')) {
+      return;
+    }
     this.JSONRPC.notification('unload');
     this.trigger('xfc.unload');
   }


### PR DESCRIPTION
### Summary
This fix checks for a download attribute in the onbeforeunload listener so that downloads aren't confused with redirects in IE11

### Additional Details
The download attribute on a link tag typically lets the browser know that the link is a download instead of a redirect and therefore skips firing the onbeforeunload listener. However, the download attribute is not supported in IE11. a workaround is to look specifically look for the download attribute and return if it is found.

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
