### PR TITLE
Don't check for same origin on embedded frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Next Release
 -------------
 
+1.5.2
+------
+* Remove check for same origin on embedded frames.
+
 1.5.1
 ------
 * Added download attribute check for IE11 in unload trigger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Next Release
 -------------
 
 * Remove frame origin check as it doesn't provide any added security value and makes
-  integration more complicated for providing applications..
+  integration more complicated for providing applications.
 
 1.5.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 Next Release
 -------------
 
-1.5.2
-------
 * Remove check for same origin on embedded frames.
 
 1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Next Release
 -------------
 
-* Remove check for same origin on embedded frames.
+* Remove frame origin check as it doesn't provide any added security value and makes
+  integration more complicated for providing applications..
 
 1.5.1
 ------

--- a/package-lock.json
+++ b/package-lock.json
@@ -3576,6 +3576,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3584,14 +3592,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -7085,6 +7085,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -7094,15 +7103,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -198,15 +198,11 @@ class Frame extends EventEmitter {
     // 2. Identify the app the message came from.
     if (this.iframe.contentWindow !== event.source) return;
 
-    // 3. Verify that the origin of the app is trusted
-    // For Chrome, the origin property is in the event.originalEvent object
-    const origin = event.origin || event.originalEvent.origin;
-    if (origin === this.origin) {
-      logger.log('<< consumer', event.origin, event.data);
+    logger.log('<< consumer', event.origin, event.data);
 
-      // 4. Send a response, if any, back to the app.
-      this.JSONRPC.handle(event.data);
-    }
+    // 3. Send a response, if any, back to the app.
+    this.JSONRPC.handle(event.data);
+
   }
 
   /**

--- a/test/frame.js
+++ b/test/frame.js
@@ -134,7 +134,7 @@ describe('Frame', () => {
         sinon.assert.notCalled(handle);
       });
 
-      it("ignores messages from different origins", () => {
+      it("doesn't ignore messages from different origins", () => {
         const event = {
           data: {jsonrpc: '2.0'},
           source: frame.iframe.contentWindow,
@@ -142,7 +142,7 @@ describe('Frame', () => {
         };
         frame.handleProviderMessage(event);
 
-        sinon.assert.notCalled(handle);
+        sinon.assert.called(handle);
       });
 
       it("calls this.JSONRPC.handle with the data of given event", () => {


### PR DESCRIPTION
Remove frame origin check as it doesn't provide any added security value and makes integration more complicated for providing applications.  

This will make it simpler for framed applications to navigate to other domains via GET and POST and allow XFC to reconnect to those.  This check doesn't provide much value because it doesn't prevent the framed site from loading, only from it communicating with the SDK. 