### PR TITLE
Keep origin up-to-date

### DIFF
--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -198,6 +198,9 @@ class Frame extends EventEmitter {
     // 2. Identify the app the message came from.
     if (this.iframe.contentWindow !== event.source) return;
 
+    // For Chrome, the origin property is in the event.originalEvent object
+    this.origin = event.origin || event.originalEvent.origin;
+    
     logger.log('<< consumer', event.origin, event.data);
 
     // 3. Send a response, if any, back to the app.

--- a/src/consumer/frame.js
+++ b/src/consumer/frame.js
@@ -198,9 +198,10 @@ class Frame extends EventEmitter {
     // 2. Identify the app the message came from.
     if (this.iframe.contentWindow !== event.source) return;
 
-    // For Chrome, the origin property is in the event.originalEvent object
+    // For Chrome, the origin property is in the event.originalEvent object.
+    // Update origin so it can be used to post back to this frame.
     this.origin = event.origin || event.originalEvent.origin;
-    
+
     logger.log('<< consumer', event.origin, event.data);
 
     // 3. Send a response, if any, back to the app.

--- a/test/frame.js
+++ b/test/frame.js
@@ -145,28 +145,6 @@ describe('Frame', () => {
         sinon.assert.called(handle);
       });
 
-      it("if the origin changes in the frame, it updates in the app", () => {
-        const event = {
-          data: {jsonrpc: '2.0'},
-          source: frame.iframe.contentWindow,
-          origin: frame.origin
-        };
-
-        frame.handleProviderMessage(event);
-
-        sinon.assert.calledWith(handle, event.data);
-
-        const event2 = {
-          data: {jsonrpc: '2.0'},
-          source: frame.iframe.contentWindow,
-          origin: 'test'
-        };
-
-        frame.handleProviderMessage(event2);
-
-        sinon.assert.calledWith(handle, event2.data);
-      });
-
       it("calls this.JSONRPC.handle with the data of given event", () => {
         const event = {
           data: {jsonrpc: '2.0'},

--- a/test/frame.js
+++ b/test/frame.js
@@ -145,6 +145,28 @@ describe('Frame', () => {
         sinon.assert.called(handle);
       });
 
+      it("if the origin changes in the frame, it updates in the app", () => {
+        const event = {
+          data: {jsonrpc: '2.0'},
+          source: frame.iframe.contentWindow,
+          origin: frame.origin
+        };
+
+        frame.handleProviderMessage(event);
+
+        sinon.assert.calledWith(handle, event.data);
+
+        const event2 = {
+          data: {jsonrpc: '2.0'},
+          source: frame.iframe.contentWindow,
+          origin: 'test'
+        };
+
+        frame.handleProviderMessage(event2);
+
+        sinon.assert.calledWith(handle, event2.data);
+      });
+
       it("calls this.JSONRPC.handle with the data of given event", () => {
         const event = {
           data: {jsonrpc: '2.0'},

--- a/test/frame.js
+++ b/test/frame.js
@@ -149,22 +149,11 @@ describe('Frame', () => {
         const event = {
           data: {jsonrpc: '2.0'},
           source: frame.iframe.contentWindow,
-          origin: frame.origin
+          origin: 'http://localhost:8080'
         };
-
         frame.handleProviderMessage(event);
 
         expect(frame.origin).to.equal(event.origin);
-
-        const event2 = {
-          data: {jsonrpc: '2.0'},
-          source: frame.iframe.contentWindow,
-          origin: 'test'
-        };
-
-        frame.handleProviderMessage(event2);
-
-        expect(frame.origin).to.equal(event2.origin);
       });
 
       it("calls this.JSONRPC.handle with the data of given event", () => {

--- a/test/frame.js
+++ b/test/frame.js
@@ -145,7 +145,7 @@ describe('Frame', () => {
         sinon.assert.called(handle);
       });
 
-      it("if the origin changes in the frame, it updates in the app", () => {
+      it("updates the app's origin to match the frame's origin", () => {
         const event = {
           data: {jsonrpc: '2.0'},
           source: frame.iframe.contentWindow,

--- a/test/frame.js
+++ b/test/frame.js
@@ -145,6 +145,28 @@ describe('Frame', () => {
         sinon.assert.called(handle);
       });
 
+      it("if the origin changes in the frame, it updates in the app", () => {
+        const event = {
+          data: {jsonrpc: '2.0'},
+          source: frame.iframe.contentWindow,
+          origin: frame.origin
+        };
+
+        frame.handleProviderMessage(event);
+
+        expect(frame.origin).to.equal(event.origin);
+
+        const event2 = {
+          data: {jsonrpc: '2.0'},
+          source: frame.iframe.contentWindow,
+          origin: 'test'
+        };
+
+        frame.handleProviderMessage(event2);
+
+        expect(frame.origin).to.equal(event2.origin);
+      });
+
       it("calls this.JSONRPC.handle with the data of given event", () => {
         const event = {
           data: {jsonrpc: '2.0'},


### PR DESCRIPTION
### Summary
Keep the origin up-to-date, so that if it changes in the frame, it updates in the app.