### PR TITLE
Add additional check for element.hasAttribute for legacy browsers

### DIFF
--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -279,7 +279,7 @@ class Application extends EventEmitter {
     const protocols = /^(tel|mailto|fax|sms|callto):/;
     const element = document.activeElement;
 
-    if (!element || !(element.hasAttribute('download') || protocols.test(element.href))) {
+    if (!element || !(false || protocols.test(element.href))) {
       this.JSONRPC.notification('unload');
       this.trigger('xfc.unload');
     }

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -279,7 +279,7 @@ class Application extends EventEmitter {
     const protocols = /^(tel|mailto|fax|sms|callto):/;
     const element = document.activeElement;
 
-    if (!element || !(false || protocols.test(element.href))) {
+    if (!element || !((element.hasAttribute && element.hasAttribute('download')) || protocols.test(element.href))) {
       this.JSONRPC.notification('unload');
       this.trigger('xfc.unload');
     }

--- a/src/provider/provider.js
+++ b/src/provider/provider.js
@@ -6,7 +6,7 @@ class Provider {
     const enforceSecurity = config.secret || config.acls.some((x) => x !== '*');
 
     // Set hidden attribute with script if not present and security is being enforced
-    if (enforceSecurity && window.self !== window.top) {
+    if (enforceSecurity && window.self !== window.top && !(document.documentElement.hasAttribute && document.documentElement.hasAttribute('hidden'))) {
       document.documentElement.setAttribute('hidden', null);
 
       // WARNING: Setting hidden attribute with script can be countered by

--- a/src/provider/provider.js
+++ b/src/provider/provider.js
@@ -6,7 +6,7 @@ class Provider {
     const enforceSecurity = config.secret || config.acls.some((x) => x !== '*');
 
     // Set hidden attribute with script if not present and security is being enforced
-    if (enforceSecurity && window.self !== window.top && !document.documentElement.hasAttribute('hidden')) {
+    if (enforceSecurity && window.self !== window.top) {
       document.documentElement.setAttribute('hidden', null);
 
       // WARNING: Setting hidden attribute with script can be countered by


### PR DESCRIPTION
### Summary
We need to add an additional check on the hasAttribute property in IE10.  This will check to make sure hasAttribute exists before we use it.

### Additional Details
This makes the code compatible with legacy browsers and is passive to newer browsers.

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to xfc.

[CONTRIBUTORS.md]: ../CONTRIBUTORS.md
[License]: ../LICENSE
