### PR TITLE
Remove code that blocks whitelisting if you have your own acl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Next Release
 -------------
-1.7.3
+1.8.0
 ------
 * Remove activeACL set by referrer, as it breaks if you have your own URL in the ACL list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Next Release
 -------------
+1.7.3
+------
+* Remove activeACL set by referrer, as it breaks if you have your own URL in the ACL list
 
 1.7.3
 ------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Cerner Corporation
 - Sam Milligan [@grneggandsam]
 - Supriti Yeotikar [@supritiy]
 - Cody Price [@dev-cprice]
+- Roxanne Calderon [@foxannefoxanne]
 
 [@mhemesath]: https://github.com/mhemesath
 [@kafkahw]: https://github.com/kafkahw
@@ -19,3 +20,4 @@ Cerner Corporation
 [@grneggandsam]: https://github.com/grneggandsam
 [@supritiy]: https://github.com/supriticerner
 [@dev-cprice]: https://github.com/dev-cprice
+[@foxannefoxanne]: https://github.com/foxannefoxanne

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xfc",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xfc",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "A Cross Frame Container that handles securely embedding web content into a 3rd party domain",
   "author": "Cerner Corporation",
   "license": "Apache-2.0",

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -34,13 +34,6 @@ class Application extends EventEmitter {
     // Resize for slow loading images
     document.addEventListener('load', this.imageRequestResize.bind(this), true);
 
-    // If the document referer (parent frame) origin is trusted, default that
-    // to the active ACL;
-    const parentOrigin = new URI(document.referrer).origin;
-    if (this.acls.includes(parentOrigin)) {
-      this.activeACL = parentOrigin;
-    }
-
     const self = this;
     this.JSONRPC = new JSONRPC(
       self.send.bind(self),

--- a/test/application.js
+++ b/test/application.js
@@ -25,23 +25,6 @@ describe('Application', () => {
     application.init({acls, secret, onReady});
     global.document = oldDocument;
 
-    it ("sets activeACL to document referrer if in ACL", () => {
-      expect(application.activeACL).to.eq(acls[0]);
-    });
-
-    it ("doesn't set activeACL to document referrer if not in ACL", () => {
-      const insecureApp = new Application();
-      global.document = {
-        referrer: 'http://evilsite.com',
-        createElement: document.createElement.bind(document),
-        addEventListener: () => console.log('mock addEventListener')
-      };
-      insecureApp.init({acls, secret, onReady});
-      global.document = oldDocument;
-
-      expect(insecureApp.activeACL).to.equal(undefined);
-    });
-
     it("sets application's acls to the given acls", () => {
       expect(application.acls).to.eql(acls);
     });


### PR DESCRIPTION
### Summary
We found an issue where inner iframe redirects do not work if you have your own ACLs whitelisted. The referrer in this code is setting the wrong activeACL so we can never properly authorize the proper URL. Because the removed codes benefit is minimal (mainly removed excess logs), it was decided it should be omitted.