### PR TITLE
 Add generic options object to App init

### DIFF
--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -17,9 +17,10 @@ class Application extends EventEmitter {
    *                                 This string must be a valid CSS selector string; if it's not,
    *                                 a SyntaxError exception is thrown.
    */
-  init({ acls = [], secret = null, onReady = null, targetSelectors = '' }) {
+  init({ acls = [], secret = null, onReady = null, targetSelectors = '', options = {} }) {
     this.acls = [].concat(acls);
     this.secret = secret;
+    this.options = options;
     this.onReady = onReady;
     this.targetSelectors = targetSelectors;
     this.resizeConfig = null;
@@ -251,7 +252,7 @@ class Application extends EventEmitter {
 
     // Emit a ready event
     this.emit('xfc.ready');
-    this.JSONRPC.notification('authorized', [{ url: window.location.href }]);
+    this.JSONRPC.notification('authorized', [{ url: window.location.href, options: this.options }]);
 
     // If there is an onReady callback, execute it
     if (typeof this.onReady === 'function') {

--- a/test/application.js
+++ b/test/application.js
@@ -209,7 +209,17 @@ describe('Application', () => {
         const notification = this.stub(application.JSONRPC, 'notification');
         application.authorizeConsumer();
 
-        sinon.assert.calledWith(notification, 'authorized', [{ url: window.location.href }]);
+        sinon.assert.calledWith(notification, 'authorized', [{ url: window.location.href, options: {} }]);
+      }));
+
+      it("calls this.JSONRPC.notification of 'authorized' with current url and generic options object", sinon.test(function() {
+        const options = { moreDetail: 'detail' }
+        const application = new Application();
+        application.init({options});
+        const notification = this.stub(application.JSONRPC, 'notification');
+        application.authorizeConsumer();
+
+        sinon.assert.calledWith(notification, 'authorized', [{ url: window.location.href, options: { moreDetail: 'detail'} }]);
       }));
 
       it("calls this.onReady if onReady is a function", () => {


### PR DESCRIPTION
### Summary
 Add generic options object to application initialization so that app can send this optional object to frame on authorization.