### PR TITLE
Support matching against wildcard characters in acls urls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Next Release
 -------------
+* Add support for wildcard characters in acls urls. 
+
 1.9.0
 ------
 * Add custom methods #47

--- a/README.md
+++ b/README.md
@@ -177,12 +177,12 @@ XFC.Provider.init({
 })
 ```
 
-If the provider is being used across the same domain with different subdomains, a wildcard character can be used.
+If the provider is being used across the same domain with different subdomains, a wildcard character can be set as the first character of the acl.
 
 ```js
 // Only load within domain.com (http://test.domain.com, https://test2.domain.com, https://test.test2.domain.com, etc.)
 XFC.Provider.init({
-  acls: ['http://*.domain.com']
+  acls: ['*.domain.com']
 })
 
 ```

--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ XFC.Provider.init({
 })
 ```
 
+If the provider is being used across the same domain with different subdomains, a wildcard character can be used.
+
+```js
+// Only load within domain.com (http://test.domain.com, https://test2.domain.com, https://test.test2.domain.com, etc.)
+XFC.Provider.init({
+  acls: ['http://*.domain.com']
+})
+
+```
+
 If the app is using secret authorization, it may pass in a secret and wildcard for authorization.
 
 ```js

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -216,8 +216,9 @@ class Application extends EventEmitter {
     }
 
     if (this.acls.includes('*') || this.acls.includes(origin) || this.acls.some((acl) => {
-      const aclRegExp = new RegExp(acl.replace('*', '[a-zA-Z0-9-._]*'));
-      return origin.match(aclRegExp);
+      // Strip leading wildcard to get domain and verify it matches the end of the event's origin.
+      const domain = acl.replace(/^\*/, '');
+      return origin.substring(origin.length - domain.length) === domain;
     })) {
       this.JSONRPC.handle(event.data);
     }

--- a/src/provider/application.js
+++ b/src/provider/application.js
@@ -216,7 +216,7 @@ class Application extends EventEmitter {
     }
 
     if (this.acls.includes('*') || this.acls.includes(origin) || this.acls.some((acl) => {
-      const aclRegExp = new RegExp(acl.replace('*', '[a-zA-Z0-9-.]*'));
+      const aclRegExp = new RegExp(acl.replace('*', '[a-zA-Z0-9-._]*'));
       return origin.match(aclRegExp);
     })) {
       this.JSONRPC.handle(event.data);

--- a/test/application.js
+++ b/test/application.js
@@ -153,7 +153,7 @@ describe('Application', () => {
         const event = {
           data: { jsonrpc: '2.0' },
           source: window.parent,
-          origin: 'http://t3St.d0-main.domain.com',
+          origin: 'http://t3_St.d0-main.domain.com',
         };
 
         application.handleConsumerMessage(event);

--- a/test/application.js
+++ b/test/application.js
@@ -17,7 +17,7 @@ describe('Application', () => {
   });
 
   describe('#init()', () => {
-    const acls = ['http://localhost:8080', 'http://*.domain.com'];
+    const acls = ['http://localhost:8080', '*.domain.com'];
     const secret = '123';
     const onReady = () => {};
     const customMethods = { add(x, y) { return Promise.resolve(x + y); } };
@@ -162,11 +162,11 @@ describe('Application', () => {
         expect(application.activeACL).to.equal(undefined);
       });
 
-      it('ignores messages with invalid domain characters', () => {
+      it('ignores messages that do not match against the origin end', () => {
         const event = {
           data: { jsonrpc: '2.0' },
           source: window.parent,
-          origin: 'http://bad#.domain.com',
+          origin: 'http://test.domain.com.bad.com',
         };
         application.handleConsumerMessage(event);
 

--- a/test/application.js
+++ b/test/application.js
@@ -173,6 +173,17 @@ describe('Application', () => {
         sinon.assert.notCalled(handle);
       });
 
+      it('ignores messages when the origin is shorter than the wildcard acl', () => {
+        const event = {
+          data: { jsonrpc: '2.0' },
+          source: window.parent,
+          origin: '.com',
+        };
+        application.handleConsumerMessage(event);
+
+        sinon.assert.notCalled(handle);
+      });
+
       it("calls this.JSONRPC.handle with the data of given event", () => {
         const event = {
           data: {jsonrpc: '2.0'},

--- a/test/application.js
+++ b/test/application.js
@@ -153,7 +153,7 @@ describe('Application', () => {
         const event = {
           data: { jsonrpc: '2.0' },
           source: window.parent,
-          origin: 'http://t3st.d0-main.domain.com',
+          origin: 'http://t3St.d0-main.domain.com',
         };
 
         application.handleConsumerMessage(event);


### PR DESCRIPTION
### Summary
Allow wildcard characters to be specified in acls urls.  This can be used to match against any domain regardless of subdomain.  Any number of valid domain characters can be matched against the asterisk.

### Additional Details
I tried to keep the regex as simple as possible.  Definitely let me know if stronger validation is needed.