### PR TITLE
Adding global window.onerrror event handler for Consumer iFrame and babel config.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,8 @@
     ["@babel/preset-env", {
       "targets": {
         "browsers": ["last 2 versions", "iOS >=10", "ie >= 10"]
-      }
+      },
+      "useBuiltIns": "usage"
     }]
   ],
   "plugins": [

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ build
 doc
 lib
 dist
-
+!src/lib
 .DS_Store

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,6 +12,7 @@ Cerner Corporation
 - Roxanne Calderon [@foxannefoxanne]
 - Yusuf Ali [@yusufali2205]
 - Jake Varness [@jvarness]
+- Shriniket Sarkar [@shriniketsarkar]
 
 [@mhemesath]: https://github.com/mhemesath
 [@kafkahw]: https://github.com/kafkahw
@@ -25,3 +26,4 @@ Cerner Corporation
 [@foxannefoxanne]: https://github.com/foxannefoxanne
 [@yusufali2205]: https://github.com/yusufali2205
 [@jvarness]: https://github.com/jvarness
+[@shriniketsarkar]: https://github.com/shriniketsarkar

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xfc",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -1,3 +1,4 @@
 import Consumer from './consumer';
+import '../lib/errorHandler';
 
 export default new Consumer();

--- a/src/lib/errorHandler.js
+++ b/src/lib/errorHandler.js
@@ -12,13 +12,14 @@
 /* eslint no-console: 0 */
 
 if (window && !window.onerror) {
-  window.onerror = (errMessage, errUrl, errLineNumber) => {
+  window.onerror = (message, source, lineno, colno, error) => {
     console.group();
     console.log('Error handled in Consumer iframe :');
-    console.log('Error Message :', errMessage);
-    console.log('URL :', errUrl);
-    console.log('LineNo :', errLineNumber);
-    console.error('Error handled in Consumer iframe :', errMessage, errUrl, errLineNumber);
+    console.log('Message :', message);
+    console.log('Source :', source);
+    console.log('Line no :', lineno);
+    console.log('Column no :', colno);
+    console.log('Error stack :', error.stack ? error.stack : '');
     console.groupEnd();
     return true;
   };

--- a/src/lib/errorHandler.js
+++ b/src/lib/errorHandler.js
@@ -1,0 +1,25 @@
+/**
+ * This code snippet handles any un-handled errors from occuring in the consumer iframe.
+ * This is a global event handler that will capture all the error messages and log them to the console.
+ * Once the error is logged to the console this onerror event handler will suppress the script error from surfacing on the UI,
+ * avoiding an interruption to the user experience by not displaying a script error.
+ *
+ * Reason for this change : In some cases when the xfc library is used in a nested iframe architecture, it results in a situation
+ * where if the outer iframe is cleared quick enough to force a re-load then postMessages from the nested iFrame result in script
+ * errors during reload.
+ */
+
+/* eslint no-console: 0 */
+
+if (window && !window.onerror) {
+  window.onerror = (errMessage, errUrl, errLineNumber) => {
+    console.group();
+    console.log('Error handled in Consumer iframe :');
+    console.log('Error Message :', errMessage);
+    console.log('URL :', errUrl);
+    console.log('LineNo :', errLineNumber);
+    console.error('Error handled in Consumer iframe :', errMessage, errUrl, errLineNumber);
+    console.groupEnd();
+    return true;
+  };
+}


### PR DESCRIPTION
### Summary
**Babel Config change :** Added in the ```useBuiltIns``` to the config to ensure any missing polyfil is available. 
**Global Error event handler :** Added a ```window.onerror``` event handler to the consumer iFrame to handle any script errors that are unexpected and unhandled in the code. This will ensure that the user does not see the script error thus improving on the user experience. 

### Additional Details
**Babel Config :** This change was needed because in IE11 browser while testing SMART on FHIR applications in MPages the Object.entries function was undefined. This babel config change ensures to add the necessary polyfills if the functionality is being used. Without this change SMART apps would not load in MPages when consuming the 1.10.1 version of xfc. 

**Global Error handler :** 

- Scenario : If xfc is used in a nested iFrame architecture (as in SMART apps in MPages) we have 2 instances of xfc being used for performing the security handshake. When the inner iframe is loading/framing a 3rd Party application it results in sending postMessage to the outer iFrame for  resizing, etc. In such a workflow if the outer iFrame is reset/reloaded/cleared during a tab sorting event in the other iframe's container it results in reloading of the outer iFrame without methodically clearing/unloading the nested inner iFrame. If this behavior happens fast enough we have observed that it results into a race condition where several messages are being sent from the nested iFrame while the other iFrame is still reloading resulting into script issues. Since we do not have any control over when the outer iFrame will get cleared we cannot initiate a cleanup before this happens. This results in the user seeing a script error that they have to click through until the application loads. 

- Script Errors : The script errors observed in such a race condition are ```Date is undefined```,  ```Object expected.```, ```parseInt is undefined```,  ```resolve is undefined``` on a Promise,  etc.
 
- Consideration : Since we know that the last queued reset/clearing operation in the user's workflow will result in a successful load of the application being framed we can suppress the script errors for a better user experience. 

- Solution : Adding a global event handler using ```window.onerror``` catches such unhandled errors and logs them to the console. 
